### PR TITLE
 Recording clips

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -13,3 +13,4 @@ This module connects to devices that support the AMP protocol.
 * Eject
 * Record
 * Load clip
+* Record clip - This creates and loads a clip for recording. To start the recording, enter the record command after sending this command. **WARNING** This command *will overwrite any clip already named what is specified currently in the bin* - there is not any error checking before running it by the device.

--- a/index.js
+++ b/index.js
@@ -321,6 +321,17 @@ instance.prototype.actions = function(system) {
 					)
 				}
 			]
+		},
+		'recordclip': {
+			label: 'Record clip',
+			options: [
+				{
+					label: 'Clip name',
+					id: 'clip',
+					type: 'textinput',
+					regex: '/^\\S.*$/'
+				}
+			]
 		}
 	});
 };
@@ -351,6 +362,14 @@ instance.prototype.action = function(action) {
 		case 'loadclip':
 			var clip = opt.clipdd || opt.clip;
 			self.sendCommand('4a14' + zpad(clip.length + 2, 4) + zpad(clip.length, 4) + str2hex(clip));
+			break;
+
+		case 'recordclip':
+			var clip = opt.clipdd || opt.clip;
+			// @todo Add a TC format (ffssmmhh)?
+			//                CMD Code      Actual Byte Count        TC Format      Clip Name Length        Clip Name
+			self.sendCommand('ae02' + zpad(clip.length + 2 + 4, 4) + '00000000' + zpad(clip.length, 4) + str2hex(clip));
+			break;
 	}
 
 	debug('action():', action.action);

--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'recordclip':
-			var clip = opt.clipdd || opt.clip;
+			var clip = opt.clip;
 			self.sendCommand(this._buildCommand('AE02', [
 				['00000000', 8], // TC
 				[clip, false, 4]
@@ -400,7 +400,7 @@ instance.prototype._buildCommand = function(name, list) {
 	list.forEach(function(cmd_str) {
 		if(cmd_str[1] === false) {
 			actual_byte_cnt += cmd_str[0].length + (cmd_str[2] / 2);
-			command += zpad(cmd_str[0].length, cmd_str[2]).toString(16);
+			command += zpad(cmd_str[0].length.toString(16), cmd_str[2]);
 			command += str2hex(cmd_str[0]);
 		} else {
 			actual_byte_cnt += cmd_str[1] / 2;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"amp"
 	],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol"


### PR DESCRIPTION
This allows support for loading a new clip that can then be recorded to.

In addition, this also fixes a bug with the way the commands are sent to the device that was incorrect. Long names would fail to load, which results in Companion losing the device connection since the device stop responding after receiving a bad formed command.