### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ class instance extends instance_skel {
 
 		const channel = this.config.channel;
 
-		this.buffer = new Buffer('');
+		this.buffer = Buffer.from('');
 
 		if (channel !== undefined) {
 			this.waiting_for_crat = true;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"amp"
 	],
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol"


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/